### PR TITLE
Include commit hash in `APP_VERSION` constant

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,11 +18,11 @@
     }
   ],
   "scripts": {
-    "start": "bun index.ts",
-    "dev": "bun --watch index.ts",
-    "lint": "bunx tsc --noEmit --skipLibCheck --pretty",
-    "test": "bun test --coverage",
-    "build": "bun build --compile ./index.ts --outfile antelope-token-api"
+    "start": "export APP_VERSION=$(git rev-parse --short HEAD) && bun index.ts",
+    "dev": "export APP_VERSION=$(git rev-parse --short HEAD) && bun --watch index.ts",
+    "lint": "export APP_VERSION=$(git rev-parse --short HEAD) && bunx tsc --noEmit --skipLibCheck --pretty",
+    "test": "export APP_VERSION=$(git rev-parse --short HEAD) && bun test --coverage",
+    "build": "export APP_VERSION=$(git rev-parse --short HEAD) && bun build --compile ./index.ts --outfile antelope-token-api"
   },
   "dependencies": {
     "@clickhouse/client-web": "latest",

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,11 +14,12 @@ export const DEFAULT_MAX_LIMIT = 10000;
 export const DEFAULT_VERBOSE = false;
 export const DEFAULT_SORT_BY = "DESC";
 export const APP_NAME = pkg.name;
+export const APP_VERSION = `${pkg.version}+${process.env.APP_VERSION || "unknown"}`;
 
 // parse command line options
 const opts = program
     .name(pkg.name)
-    .version(pkg.version)
+    .version(APP_VERSION)
     .description(pkg.description)
     .showHelpAfterError()
     .addOption(new Option("-p, --port <number>", "HTTP port on which to attach the API").env("PORT").default(DEFAULT_PORT))

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,11 +1,11 @@
 import { Logger, type ILogObj } from "tslog";
-import { name } from "../package.json" assert { type: "json" };
+import { APP_NAME, APP_VERSION } from "./config.js";
 
 class TsLogger extends Logger<ILogObj> {
     constructor() {
         super();
         this.settings.minLevel = 5;
-        this.settings.name = name;
+        this.settings.name = `${APP_NAME}:${APP_VERSION}`;
     }
 
     public enable(type: "pretty" | "json" = "pretty") {


### PR DESCRIPTION
Try to read the commit hash from the `APP_VERSION` environment variable and export it along the API release version in `config.ts`.