### PR TITLE
Remove coercion for string parameters

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -104,7 +104,7 @@ function AntelopeTokenAPI() {
                             p[key] = z.coerce.date();
                             // Any other type will be coerced as string value directly
                         } else {
-                            p[key] = z.coerce.string();
+                            p[key] = z.string();
                         }
 
                         if (isOptional)


### PR DESCRIPTION
If the parameters are not supplied, the coercion will actually return them as 'undefined' string which is not the expected behavior.