### PR TITLE
Rework endpoints and support `X-Api-Key` header auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,6 @@ HOST=http://127.0.0.1:8123
 DATABASE=default
 USERNAME=default
 PASSWORD=
-TABLE=
 MAX_LIMIT=500
 
 # Logging

--- a/.github/workflows/bun-test.yml
+++ b/.github/workflows/bun-test.yml
@@ -29,4 +29,3 @@ jobs:
           HOST: ${{ vars.HOST }}
           USERNAME: ${{ secrets.USERNAME }}
           PASSWORD: ${{ secrets.PASSWORD }}
-          TABLE: ${{ secrets.TABLE }}

--- a/README.md
+++ b/README.md
@@ -7,20 +7,22 @@
 <a href="https://pinax.network/en/chain/eos"><img src="https://img.shields.io/badge/EOS-grey?style=for-the-badge&logo=data:image/svg%2bxml;base64,PHN2ZyB3aWR0aD0iNjciIGhlaWdodD0iMTAxIiB2aWV3Qm94PSIwIDAgNjcgMTAxIiBmaWxsPSJub25lIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPg0KPGcgY2xpcC1wYXRoPSJ1cmwoI2NsaXAwXzY2XzI5KSI+DQo8cGF0aCBkPSJNMzMuMzUwOCAwLjIyMTE5MUw5Ljk1MDg2IDMyLjQyMTJMMC4xNTA4NzkgODAuMDIxMkwzMy4zNTA4IDEwMC4yMjFMNjYuNTUwOCA4MC4wMjEyTDU2LjU1MDggMzIuMjIxMkwzMy4zNTA4IDAuMjIxMTkxWk01LjU1MDg3IDc3LjgyMTJMMTIuOTUwOSA0MS42MjEyTDI5Ljc1MDggOTIuNjIxMkw1LjU1MDg3IDc3LjgyMTJaTTE1LjM1MDkgMzMuNDIxMkwzMy4zNTA4IDguNjIxMTlMNTEuMzUwOCAzMy40MjEyTDMzLjM1MDggODcuODIxMkwxNS4zNTA5IDMzLjQyMTJaTTM2Ljc1MDggOTIuNjIxMkw1My41NTA4IDQxLjYyMTJMNjAuOTUwOCA3Ny44MjEyTDM2Ljc1MDggOTIuNjIxMloiIGZpbGw9IndoaXRlIi8+DQo8L2c+DQo8ZGVmcz4NCjxjbGlwUGF0aCBpZD0iY2xpcDBfNjZfMjkiPg0KPHJlY3Qgd2lkdGg9IjY2LjM5OTkiIGhlaWdodD0iMTAwIiBmaWxsPSJ3aGl0ZSIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMC4xNTA4NzkgMC4yMjExOTEpIi8+DQo8L2NsaXBQYXRoPg0KPC9kZWZzPg0KPC9zdmc+DQo=&logoSize=auto" height="30" /></a>
 <a href="https://pinax.network/en/chain/wax"><img src="https://img.shields.io/badge/WAX-grey?style=for-the-badge&logo=data%3Aimage%2Fsvg%2Bxml%3Bbase64%2CPHN2ZyB3aWR0aD0iMTAxIiBoZWlnaHQ9IjEwMSIgdmlld0JveD0iMCAwIDEwMSAxMDEiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI%2BDQo8ZyBjbGlwLXBhdGg9InVybCgjY2xpcDBfNjdfOSkiPg0KPHBhdGggZD0iTTUwLjEzOTQgMTAwLjIyMUM3Ny43NTM2IDEwMC4yMjEgMTAwLjEzOSA3Ny44MzU0IDEwMC4xMzkgNTAuMjIxMkMxMDAuMTM5IDIyLjYwNyA3Ny43NTM2IDAuMjIxMTkxIDUwLjEzOTQgMC4yMjExOTFDMjIuNTI1MiAwLjIyMTE5MSAwLjEzOTQwNCAyMi42MDcgMC4xMzk0MDQgNTAuMjIxMkMwLjEzOTQwNCA3Ny44MzU0IDIyLjUyNTIgMTAwLjIyMSA1MC4xMzk0IDEwMC4yMjFaIiBmaWxsPSIjRjg5MDIyIi8%2BDQo8cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTg3LjYzOTUgNTkuNDc3Mkg4MC4yNTJMNzUuMDExNCA1NC45ODk3TDY5Ljc4OTUgNTkuNDU4NEg2My41NDU4TDYwLjU2MTQgNTUuODMzNEg1MC4yNzM5TDUyLjg3NyA1Mi42MTc4SDU3LjkzNjRMNTQuMDgzMyA0Ny45MDUzTDQwLjYzMDIgNjQuMjgzNEgzNC4zODk1TDM4LjI4MzMgNTkuNTI3MkgzMS43ODAyTDI4LjI2NDUgNDkuNjcwOUwyNC43NzcgNTkuNDUyMkgxOC4xODAyTDEyLjYzOTUgNDQuMDk5MUgxNy43MDJMMjEuNDI3IDU0LjU1NTNMMjUuMTM5NSA0NC4xNDU5SDMxLjM4OTVMMzUuMDkyNyA1NC41MzM0TDM4Ljc5MjcgNDQuMTQyOEg0My44NzA4TDM4LjI4MzMgNTkuNTI3MkwzOS41MjcgNTguMDA4NEw1MC45Mzk1IDQ0LjExNzhINTcuMjIwOEw2Ni43MTc3IDU1LjcwNTNMNzEuMjg2NCA1MS43NzcyTDU2LjgyNyAzOS4yODM0SDY0LjI0ODlMODcuNjM5NSA1OS40NzcyWk04MC4zMTE0IDUwLjE4OTdMNzYuODI3IDQ3LjIwMjJMODAuMzA1MiA0NC4yMzk3TDg3LjMzNjQgNDQuMjQ1OUw4MC4zMTE0IDUwLjE4OTdaIiBmaWxsPSJ3aGl0ZSIvPg0KPC9nPg0KPGRlZnM%2BDQo8Y2xpcFBhdGggaWQ9ImNsaXAwXzY3XzkiPg0KPHJlY3Qgd2lkdGg9IjEwMCIgaGVpZ2h0PSIxMDAiIGZpbGw9IndoaXRlIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgwLjEzOTQwNCAwLjIyMTE5MSkiLz4NCjwvY2xpcFBhdGg%2BDQo8L2RlZnM%2BDQo8L3N2Zz4NCg%3D%3D&logoSize=auto" height="30" /></a>
 
-## REST API
+## Swagger API
 
 ### Usage
 
 | Method | Path | Query parameters<br>(* = **Required**) | Description |
 | :---: | --- | --- | --- |
 | GET <br>`text/html` | `/` | - | [Swagger](https://swagger.io/) API playground |
-| GET <br>`application/json` | `/chains` | `limit`<br>`page` | Information about the chains and latest head block in the database |
-| GET <br>`application/json` | `/{chain}/balance` | `block_num`<br>`contract`<br>`symcode`<br>**`account*`**<br>`limit`<br>`page` | Balances of an account. |
-| GET <br>`application/json` | `/{chain}/holders` | **`contract*`**<br>**`symcode*`**<br>`limit`<br>`page` | List of holders of a token |
-| GET <br>`application/json` | `/{chain}/supply` | `block_num`<br>`issuer`<br>**`contract*`**<br>**`symcode*`**<br>`limit`<br>`page` | Total supply for a token |
-| GET <br>`application/json` | `/{chain}/tokens` | `limit`<br>`page` | List of available tokens |
-| GET <br>`application/json` | `/{chain}/transfers` | `block_range`<br>`from`<br>`to`<br>`contract`<br>`symcode`<br>`limit`<br>`page` | All transfers related to a token |
-| GET <br>`application/json` | `/{chain}/transfers/{trx_id}` | `limit`<br>`page` | Specific transfer related to a token |
+| GET <br>`application/json` | `/balance` | **`account*`**<br>`contract`<br>`symcode`<br>`limit`<br>`page` | Balances of an account |
+| GET <br>`application/json` | `/balance/historical` | **`account*`**<br>`block_num`<br>`contract`<br>`symcode`<br>`limit`<br>`page` | Historical token balances |
+| GET <br>`application/json` | `/head` | `limit`<br>`page` | Head block information |
+| GET <br>`application/json` | `/holders` | **`contract*`**<br>**`symcode*`**<br>`limit`<br>`page` | List of holders of a token |
+| GET <br>`application/json` | `/supply` | `block_num`<br>`issuer`<br>**`contract*`**<br>**`symcode*`**<br>`limit`<br>`page` | Total supply for a token |
+| GET <br>`application/json` | `/tokens` | `limit`<br>`page` | List of available tokens |
+| GET <br>`application/json` | `/transfers` | `block_range`<br>**`contract*`**<br>**`symcode*`**<br>`limit`<br>`page` | All transfers related to a token |
+| GET <br>`application/json` | `/transfers/account` | **`account*`**<br>`block_range`<br>`from`<br>`to`<br>`contract`<br>`symcode`<br>`limit`<br>`page` | All transfers related to an account |
+| GET <br>`application/json` | `/transfers/id` | **`trx_id*`**<br>`limit`<br>`page` | Specific transfer related to a token |
 
 ### Docs
 
@@ -40,12 +42,20 @@
 
 Go to `/graphql` for a GraphIQL interface.
 
+### `X-Api-Key`
+
+Use the `Variables` tab at the bottom to add your API key:
+```json
+{
+  "X-Api-Key": "changeme"
+}
+```
+
 ### Additional notes
 
 - For the `block_range` parameter in `transfers`, you can pass a single integer value (low bound) or an array of two values (inclusive range).
-- If you input the same account in the `from` and `to` field for transfers, you'll get all inbound and outbound transfers for that account.
-- The more parameters you add (i.e. the more precise your query is), the faster it should be for the back-end to fetch it.
-- Don't forget to request for the `meta` fields in the response to get access to pagination and statistics !
+- Use the `from` and `to` field for transfers of an account to further filter the results (i.e. incoming or outgoing transactions from/to another account).
+- Don't forget to request the `meta` fields in the response to get access to pagination and statistics !
 
 ## Requirements
 
@@ -158,7 +168,6 @@ HOST=http://127.0.0.1:8123
 DATABASE=default
 USERNAME=default
 PASSWORD=
-TABLE=
 MAX_LIMIT=500
 
 # Logging

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "antelope-token-api",
   "description": "Token balances, supply and transfers from the Antelope blockchains",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "homepage": "https://github.com/pinax-network/antelope-token-api",
   "license": "MIT",
   "authors": [
@@ -38,7 +38,7 @@
     "lint": "export APP_VERSION=$(git rev-parse --short HEAD) && bun run tsc --noEmit --skipLibCheck --pretty",
     "start": "export APP_VERSION=$(git rev-parse --short HEAD) && bun index.ts",
     "test": "bun test --coverage",
-    "types": "bun run tsp compile ./src/typespec --output-dir static && bun run openapi-to-graphql ./static/@typespec/openapi3/openapi.json --save static/@openapi-to-graphql/graphql/schema.graphql --simpleNames --singularNames && bun run kubb",
+    "types": "bun run tsp compile ./src/typespec --output-dir static && bun run openapi-to-graphql ./static/@typespec/openapi3/openapi.json --save static/@openapi-to-graphql/graphql/schema.graphql --simpleNames --singularNames --no-viewer -H 'X-Api-Key:changeme' && bun run kubb",
     "types:check": "bun run tsp compile ./src/typespec --no-emit --pretty --warn-as-error",
     "types:format": "bun run tsp format src/typespec/**/*.tsp",
     "types:watch": "bun run tsp compile ./src/typespec --watch --pretty --warn-as-error"

--- a/src/types/zod.gen.ts
+++ b/src/types/zod.gen.ts
@@ -5,12 +5,20 @@ export const apiErrorSchema = z.object({ "status": z.union([z.literal(500), z.li
 export type ApiErrorSchema = z.infer<typeof apiErrorSchema>;
 
 
+export const balanceSchema = z.object({ "last_updated_block": z.coerce.number(), "contract": z.coerce.string(), "symcode": z.coerce.string(), "balance": z.coerce.number() });
+export type BalanceSchema = z.infer<typeof balanceSchema>;
+
+
 export const balanceChangeSchema = z.object({ "trx_id": z.coerce.string(), "action_index": z.coerce.number(), "contract": z.coerce.string(), "symcode": z.coerce.string(), "precision": z.coerce.number(), "amount": z.coerce.number(), "value": z.coerce.number(), "block_num": z.coerce.number(), "timestamp": z.coerce.string(), "account": z.coerce.string(), "balance": z.coerce.string(), "balance_delta": z.coerce.number() });
 export type BalanceChangeSchema = z.infer<typeof balanceChangeSchema>;
 
 
 export const holderSchema = z.object({ "account": z.coerce.string(), "balance": z.coerce.number() });
 export type HolderSchema = z.infer<typeof holderSchema>;
+
+
+export const modelsScopeSchema = z.object({ "contract": z.coerce.string(), "symcode": z.coerce.string() });
+export type ModelsScopeSchema = z.infer<typeof modelsScopeSchema>;
 
 
 export const paginationSchema = z.object({ "next_page": z.coerce.number(), "previous_page": z.coerce.number(), "total_pages": z.coerce.number(), "total_results": z.coerce.number() });
@@ -29,10 +37,6 @@ export const supplySchema = z.object({ "trx_id": z.coerce.string(), "action_inde
 export type SupplySchema = z.infer<typeof supplySchema>;
 
 
-export const supportedChainsSchema = z.enum(["EOS", "WAX"]);
-export type SupportedChainsSchema = z.infer<typeof supportedChainsSchema>;
-
-
 export const transferSchema = z.object({ "trx_id": z.coerce.string(), "action_index": z.coerce.number(), "contract": z.coerce.string(), "symcode": z.coerce.string(), "precision": z.coerce.number(), "amount": z.coerce.number(), "value": z.coerce.number(), "block_num": z.coerce.number(), "timestamp": z.coerce.string(), "from": z.coerce.string(), "to": z.coerce.string(), "quantity": z.coerce.string(), "memo": z.coerce.string() });
 export type TransferSchema = z.infer<typeof transferSchema>;
 
@@ -41,26 +45,64 @@ export const versionSchema = z.object({ "version": z.coerce.string().regex(new R
 export type VersionSchema = z.infer<typeof versionSchema>;
 
 
-export const usageChainsQueryParamsSchema = z.object({ "limit": z.coerce.number().optional(), "page": z.coerce.number().optional() }).optional();
-export type UsageChainsQueryParamsSchema = z.infer<typeof usageChainsQueryParamsSchema>;
+export const usageBalanceQueryParamsSchema = z.object({ "account": z.coerce.string(), "contract": z.coerce.string().optional(), "symcode": z.coerce.string().optional(), "limit": z.coerce.number().optional(), "page": z.coerce.number().optional() });
+export type UsageBalanceQueryParamsSchema = z.infer<typeof usageBalanceQueryParamsSchema>;
 /**
- * @description Array of block information.
+ * @description Array of balances.
  */
-export const usageChains200Schema = z.object({ "data": z.array(z.object({ "chain": z.lazy(() => supportedChainsSchema), "block_num": z.coerce.number() })), "meta": z.lazy(() => responseMetadataSchema) });
-export type UsageChains200Schema = z.infer<typeof usageChains200Schema>;
+export const usageBalance200Schema = z.object({ "data": z.array(z.lazy(() => balanceSchema)), "meta": z.lazy(() => responseMetadataSchema) });
+export type UsageBalance200Schema = z.infer<typeof usageBalance200Schema>;
 /**
  * @description An unexpected error response.
  */
-export const usageChainsErrorSchema = z.lazy(() => apiErrorSchema);
-export type UsageChainsErrorSchema = z.infer<typeof usageChainsErrorSchema>;
+export const usageBalanceErrorSchema = z.lazy(() => apiErrorSchema);
+export type UsageBalanceErrorSchema = z.infer<typeof usageBalanceErrorSchema>;
 /**
- * @description Array of block information.
+ * @description Array of balances.
  */
-export const usageChainsQueryResponseSchema = z.object({ "data": z.array(z.object({ "chain": z.lazy(() => supportedChainsSchema), "block_num": z.coerce.number() })), "meta": z.lazy(() => responseMetadataSchema) });
-export type UsageChainsQueryResponseSchema = z.infer<typeof usageChainsQueryResponseSchema>;
+export const usageBalanceQueryResponseSchema = z.object({ "data": z.array(z.lazy(() => balanceSchema)), "meta": z.lazy(() => responseMetadataSchema) });
+export type UsageBalanceQueryResponseSchema = z.infer<typeof usageBalanceQueryResponseSchema>;
+
+
+export const usageBalanceHistoricalQueryParamsSchema = z.object({ "account": z.coerce.string(), "block_num": z.coerce.number(), "contract": z.coerce.string().optional(), "symcode": z.coerce.string().optional(), "limit": z.coerce.number().optional(), "page": z.coerce.number().optional() });
+export type UsageBalanceHistoricalQueryParamsSchema = z.infer<typeof usageBalanceHistoricalQueryParamsSchema>;
+/**
+ * @description Array of balances.
+ */
+export const usageBalanceHistorical200Schema = z.object({ "data": z.array(z.lazy(() => balanceChangeSchema)), "meta": z.lazy(() => responseMetadataSchema) });
+export type UsageBalanceHistorical200Schema = z.infer<typeof usageBalanceHistorical200Schema>;
+/**
+ * @description An unexpected error response.
+ */
+export const usageBalanceHistoricalErrorSchema = z.lazy(() => apiErrorSchema);
+export type UsageBalanceHistoricalErrorSchema = z.infer<typeof usageBalanceHistoricalErrorSchema>;
+/**
+ * @description Array of balances.
+ */
+export const usageBalanceHistoricalQueryResponseSchema = z.object({ "data": z.array(z.lazy(() => balanceChangeSchema)), "meta": z.lazy(() => responseMetadataSchema) });
+export type UsageBalanceHistoricalQueryResponseSchema = z.infer<typeof usageBalanceHistoricalQueryResponseSchema>;
+
+
+export const usageHeadQueryParamsSchema = z.object({ "limit": z.coerce.number().optional(), "page": z.coerce.number().optional() }).optional();
+export type UsageHeadQueryParamsSchema = z.infer<typeof usageHeadQueryParamsSchema>;
+/**
+ * @description Head block information.
+ */
+export const usageHead200Schema = z.object({ "data": z.array(z.object({ "block_num": z.coerce.number(), "block_id": z.coerce.string() })), "meta": z.lazy(() => responseMetadataSchema) });
+export type UsageHead200Schema = z.infer<typeof usageHead200Schema>;
+/**
+ * @description An unexpected error response.
+ */
+export const usageHeadErrorSchema = z.lazy(() => apiErrorSchema);
+export type UsageHeadErrorSchema = z.infer<typeof usageHeadErrorSchema>;
+/**
+ * @description Head block information.
+ */
+export const usageHeadQueryResponseSchema = z.object({ "data": z.array(z.object({ "block_num": z.coerce.number(), "block_id": z.coerce.string() })), "meta": z.lazy(() => responseMetadataSchema) });
+export type UsageHeadQueryResponseSchema = z.infer<typeof usageHeadQueryResponseSchema>;
 
  /**
- * @description OK or APIError.
+ * @description OK or ApiError.
  */
 export const monitoringHealth200Schema = z.coerce.string();
 export type MonitoringHealth200Schema = z.infer<typeof monitoringHealth200Schema>;
@@ -70,10 +112,29 @@ export type MonitoringHealth200Schema = z.infer<typeof monitoringHealth200Schema
 export const monitoringHealthErrorSchema = z.lazy(() => apiErrorSchema);
 export type MonitoringHealthErrorSchema = z.infer<typeof monitoringHealthErrorSchema>;
 /**
- * @description OK or APIError.
+ * @description OK or ApiError.
  */
 export const monitoringHealthQueryResponseSchema = z.coerce.string();
 export type MonitoringHealthQueryResponseSchema = z.infer<typeof monitoringHealthQueryResponseSchema>;
+
+
+export const usageHoldersQueryParamsSchema = z.object({ "contract": z.coerce.string(), "symcode": z.coerce.string(), "limit": z.coerce.number().optional(), "page": z.coerce.number().optional() });
+export type UsageHoldersQueryParamsSchema = z.infer<typeof usageHoldersQueryParamsSchema>;
+/**
+ * @description Array of accounts.
+ */
+export const usageHolders200Schema = z.object({ "data": z.array(z.lazy(() => holderSchema)), "meta": z.lazy(() => responseMetadataSchema) });
+export type UsageHolders200Schema = z.infer<typeof usageHolders200Schema>;
+/**
+ * @description An unexpected error response.
+ */
+export const usageHoldersErrorSchema = z.lazy(() => apiErrorSchema);
+export type UsageHoldersErrorSchema = z.infer<typeof usageHoldersErrorSchema>;
+/**
+ * @description Array of accounts.
+ */
+export const usageHoldersQueryResponseSchema = z.object({ "data": z.array(z.lazy(() => holderSchema)), "meta": z.lazy(() => responseMetadataSchema) });
+export type UsageHoldersQueryResponseSchema = z.infer<typeof usageHoldersQueryResponseSchema>;
 
  /**
  * @description Metrics as text.
@@ -107,71 +168,8 @@ export type DocsOpenapiErrorSchema = z.infer<typeof docsOpenapiErrorSchema>;
 export const docsOpenapiQueryResponseSchema = z.object({});
 export type DocsOpenapiQueryResponseSchema = z.infer<typeof docsOpenapiQueryResponseSchema>;
 
- /**
- * @description The API version and commit hash.
- */
-export const docsVersion200Schema = z.lazy(() => versionSchema);
-export type DocsVersion200Schema = z.infer<typeof docsVersion200Schema>;
-/**
- * @description An unexpected error response.
- */
-export const docsVersionErrorSchema = z.lazy(() => apiErrorSchema);
-export type DocsVersionErrorSchema = z.infer<typeof docsVersionErrorSchema>;
-/**
- * @description The API version and commit hash.
- */
-export const docsVersionQueryResponseSchema = z.lazy(() => versionSchema);
-export type DocsVersionQueryResponseSchema = z.infer<typeof docsVersionQueryResponseSchema>;
 
-
-export const usageBalancePathParamsSchema = z.object({ "chain": z.lazy(() => supportedChainsSchema) });
-export type UsageBalancePathParamsSchema = z.infer<typeof usageBalancePathParamsSchema>;
-
- export const usageBalanceQueryParamsSchema = z.object({ "block_num": z.coerce.number().optional(), "contract": z.coerce.string().optional(), "symcode": z.coerce.string().optional(), "account": z.coerce.string(), "limit": z.coerce.number().optional(), "page": z.coerce.number().optional() });
-export type UsageBalanceQueryParamsSchema = z.infer<typeof usageBalanceQueryParamsSchema>;
-/**
- * @description Array of balances.
- */
-export const usageBalance200Schema = z.object({ "data": z.array(z.lazy(() => balanceChangeSchema)), "meta": z.lazy(() => responseMetadataSchema) });
-export type UsageBalance200Schema = z.infer<typeof usageBalance200Schema>;
-/**
- * @description An unexpected error response.
- */
-export const usageBalanceErrorSchema = z.lazy(() => apiErrorSchema);
-export type UsageBalanceErrorSchema = z.infer<typeof usageBalanceErrorSchema>;
-/**
- * @description Array of balances.
- */
-export const usageBalanceQueryResponseSchema = z.object({ "data": z.array(z.lazy(() => balanceChangeSchema)), "meta": z.lazy(() => responseMetadataSchema) });
-export type UsageBalanceQueryResponseSchema = z.infer<typeof usageBalanceQueryResponseSchema>;
-
-
-export const usageHoldersPathParamsSchema = z.object({ "chain": z.lazy(() => supportedChainsSchema) });
-export type UsageHoldersPathParamsSchema = z.infer<typeof usageHoldersPathParamsSchema>;
-
- export const usageHoldersQueryParamsSchema = z.object({ "contract": z.coerce.string(), "symcode": z.coerce.string(), "limit": z.coerce.number().optional(), "page": z.coerce.number().optional() });
-export type UsageHoldersQueryParamsSchema = z.infer<typeof usageHoldersQueryParamsSchema>;
-/**
- * @description Array of accounts.
- */
-export const usageHolders200Schema = z.object({ "data": z.array(z.lazy(() => holderSchema)), "meta": z.lazy(() => responseMetadataSchema) });
-export type UsageHolders200Schema = z.infer<typeof usageHolders200Schema>;
-/**
- * @description An unexpected error response.
- */
-export const usageHoldersErrorSchema = z.lazy(() => apiErrorSchema);
-export type UsageHoldersErrorSchema = z.infer<typeof usageHoldersErrorSchema>;
-/**
- * @description Array of accounts.
- */
-export const usageHoldersQueryResponseSchema = z.object({ "data": z.array(z.lazy(() => holderSchema)), "meta": z.lazy(() => responseMetadataSchema) });
-export type UsageHoldersQueryResponseSchema = z.infer<typeof usageHoldersQueryResponseSchema>;
-
-
-export const usageSupplyPathParamsSchema = z.object({ "chain": z.lazy(() => supportedChainsSchema) });
-export type UsageSupplyPathParamsSchema = z.infer<typeof usageSupplyPathParamsSchema>;
-
- export const usageSupplyQueryParamsSchema = z.object({ "block_num": z.coerce.number().optional(), "issuer": z.coerce.string().optional(), "contract": z.coerce.string(), "symcode": z.coerce.string(), "limit": z.coerce.number().optional(), "page": z.coerce.number().optional() });
+export const usageSupplyQueryParamsSchema = z.object({ "block_num": z.coerce.number().optional(), "issuer": z.coerce.string().optional(), "contract": z.coerce.string(), "symcode": z.coerce.string(), "limit": z.coerce.number().optional(), "page": z.coerce.number().optional() });
 export type UsageSupplyQueryParamsSchema = z.infer<typeof usageSupplyQueryParamsSchema>;
 /**
  * @description Array of supplies.
@@ -190,15 +188,12 @@ export const usageSupplyQueryResponseSchema = z.object({ "data": z.array(z.lazy(
 export type UsageSupplyQueryResponseSchema = z.infer<typeof usageSupplyQueryResponseSchema>;
 
 
-export const usageTokensPathParamsSchema = z.object({ "chain": z.lazy(() => supportedChainsSchema) });
-export type UsageTokensPathParamsSchema = z.infer<typeof usageTokensPathParamsSchema>;
-
- export const usageTokensQueryParamsSchema = z.object({ "limit": z.coerce.number().optional(), "page": z.coerce.number().optional() }).optional();
+export const usageTokensQueryParamsSchema = z.object({ "limit": z.coerce.number().optional(), "page": z.coerce.number().optional() }).optional();
 export type UsageTokensQueryParamsSchema = z.infer<typeof usageTokensQueryParamsSchema>;
 /**
- * @description Array of supplies.
+ * @description Array of token identifier.
  */
-export const usageTokens200Schema = z.object({ "data": z.array(z.lazy(() => supplySchema)), "meta": z.lazy(() => responseMetadataSchema) });
+export const usageTokens200Schema = z.object({ "data": z.array(z.lazy(() => modelsScopeSchema)), "meta": z.lazy(() => responseMetadataSchema) });
 export type UsageTokens200Schema = z.infer<typeof usageTokens200Schema>;
 /**
  * @description An unexpected error response.
@@ -206,16 +201,13 @@ export type UsageTokens200Schema = z.infer<typeof usageTokens200Schema>;
 export const usageTokensErrorSchema = z.lazy(() => apiErrorSchema);
 export type UsageTokensErrorSchema = z.infer<typeof usageTokensErrorSchema>;
 /**
- * @description Array of supplies.
+ * @description Array of token identifier.
  */
-export const usageTokensQueryResponseSchema = z.object({ "data": z.array(z.lazy(() => supplySchema)), "meta": z.lazy(() => responseMetadataSchema) });
+export const usageTokensQueryResponseSchema = z.object({ "data": z.array(z.lazy(() => modelsScopeSchema)), "meta": z.lazy(() => responseMetadataSchema) });
 export type UsageTokensQueryResponseSchema = z.infer<typeof usageTokensQueryResponseSchema>;
 
 
-export const usageTransfersPathParamsSchema = z.object({ "chain": z.lazy(() => supportedChainsSchema) });
-export type UsageTransfersPathParamsSchema = z.infer<typeof usageTransfersPathParamsSchema>;
-
- export const usageTransfersQueryParamsSchema = z.object({ "block_range": z.array(z.coerce.number()).optional(), "from": z.coerce.string().optional(), "to": z.coerce.string().optional(), "contract": z.coerce.string().optional(), "symcode": z.coerce.string().optional(), "limit": z.coerce.number().optional(), "page": z.coerce.number().optional() }).optional();
+export const usageTransfersQueryParamsSchema = z.object({ "block_range": z.array(z.coerce.number()).optional(), "contract": z.coerce.string(), "symcode": z.coerce.string(), "limit": z.coerce.number().optional(), "page": z.coerce.number().optional() });
 export type UsageTransfersQueryParamsSchema = z.infer<typeof usageTransfersQueryParamsSchema>;
 /**
  * @description Array of transfers.
@@ -234,37 +226,93 @@ export const usageTransfersQueryResponseSchema = z.object({ "data": z.array(z.la
 export type UsageTransfersQueryResponseSchema = z.infer<typeof usageTransfersQueryResponseSchema>;
 
 
-export const usageTransferPathParamsSchema = z.object({ "chain": z.lazy(() => supportedChainsSchema), "trx_id": z.coerce.string() });
-export type UsageTransferPathParamsSchema = z.infer<typeof usageTransferPathParamsSchema>;
-
- export const usageTransferQueryParamsSchema = z.object({ "limit": z.coerce.number().optional(), "page": z.coerce.number().optional() }).optional();
-export type UsageTransferQueryParamsSchema = z.infer<typeof usageTransferQueryParamsSchema>;
+export const usageTransfersAccountQueryParamsSchema = z.object({ "account": z.coerce.string(), "block_range": z.array(z.coerce.number()).optional(), "from": z.coerce.string().optional(), "to": z.coerce.string().optional(), "contract": z.coerce.string().optional(), "symcode": z.coerce.string().optional(), "limit": z.coerce.number().optional(), "page": z.coerce.number().optional() });
+export type UsageTransfersAccountQueryParamsSchema = z.infer<typeof usageTransfersAccountQueryParamsSchema>;
 /**
  * @description Array of transfers.
  */
-export const usageTransfer200Schema = z.object({ "data": z.array(z.lazy(() => transferSchema)), "meta": z.lazy(() => responseMetadataSchema) });
-export type UsageTransfer200Schema = z.infer<typeof usageTransfer200Schema>;
+export const usageTransfersAccount200Schema = z.object({ "data": z.array(z.lazy(() => transferSchema)), "meta": z.lazy(() => responseMetadataSchema) });
+export type UsageTransfersAccount200Schema = z.infer<typeof usageTransfersAccount200Schema>;
 /**
  * @description An unexpected error response.
  */
-export const usageTransferErrorSchema = z.lazy(() => apiErrorSchema);
-export type UsageTransferErrorSchema = z.infer<typeof usageTransferErrorSchema>;
+export const usageTransfersAccountErrorSchema = z.lazy(() => apiErrorSchema);
+export type UsageTransfersAccountErrorSchema = z.infer<typeof usageTransfersAccountErrorSchema>;
 /**
  * @description Array of transfers.
  */
-export const usageTransferQueryResponseSchema = z.object({ "data": z.array(z.lazy(() => transferSchema)), "meta": z.lazy(() => responseMetadataSchema) });
-export type UsageTransferQueryResponseSchema = z.infer<typeof usageTransferQueryResponseSchema>;
+export const usageTransfersAccountQueryResponseSchema = z.object({ "data": z.array(z.lazy(() => transferSchema)), "meta": z.lazy(() => responseMetadataSchema) });
+export type UsageTransfersAccountQueryResponseSchema = z.infer<typeof usageTransfersAccountQueryResponseSchema>;
 
- export const operations = { "Usage_chains": {
+
+export const usageTransferIdQueryParamsSchema = z.object({ "trx_id": z.coerce.string(), "limit": z.coerce.number().optional(), "page": z.coerce.number().optional() });
+export type UsageTransferIdQueryParamsSchema = z.infer<typeof usageTransferIdQueryParamsSchema>;
+/**
+ * @description Array of transfers.
+ */
+export const usageTransferId200Schema = z.object({ "data": z.array(z.lazy(() => transferSchema)), "meta": z.lazy(() => responseMetadataSchema) });
+export type UsageTransferId200Schema = z.infer<typeof usageTransferId200Schema>;
+/**
+ * @description An unexpected error response.
+ */
+export const usageTransferIdErrorSchema = z.lazy(() => apiErrorSchema);
+export type UsageTransferIdErrorSchema = z.infer<typeof usageTransferIdErrorSchema>;
+/**
+ * @description Array of transfers.
+ */
+export const usageTransferIdQueryResponseSchema = z.object({ "data": z.array(z.lazy(() => transferSchema)), "meta": z.lazy(() => responseMetadataSchema) });
+export type UsageTransferIdQueryResponseSchema = z.infer<typeof usageTransferIdQueryResponseSchema>;
+
+ /**
+ * @description The Api version and commit hash.
+ */
+export const docsVersion200Schema = z.lazy(() => versionSchema);
+export type DocsVersion200Schema = z.infer<typeof docsVersion200Schema>;
+/**
+ * @description An unexpected error response.
+ */
+export const docsVersionErrorSchema = z.lazy(() => apiErrorSchema);
+export type DocsVersionErrorSchema = z.infer<typeof docsVersionErrorSchema>;
+/**
+ * @description The Api version and commit hash.
+ */
+export const docsVersionQueryResponseSchema = z.lazy(() => versionSchema);
+export type DocsVersionQueryResponseSchema = z.infer<typeof docsVersionQueryResponseSchema>;
+
+ export const operations = { "Usage_balance": {
         request: undefined,
         parameters: {
             path: undefined,
-            query: usageChainsQueryParamsSchema,
+            query: usageBalanceQueryParamsSchema,
             header: undefined
         },
         responses: {
-            200: usageChainsQueryResponseSchema,
-            default: usageChainsQueryResponseSchema
+            200: usageBalanceQueryResponseSchema,
+            default: usageBalanceQueryResponseSchema
+        },
+        errors: {}
+    }, "Usage_balanceHistorical": {
+        request: undefined,
+        parameters: {
+            path: undefined,
+            query: usageBalanceHistoricalQueryParamsSchema,
+            header: undefined
+        },
+        responses: {
+            200: usageBalanceHistoricalQueryResponseSchema,
+            default: usageBalanceHistoricalQueryResponseSchema
+        },
+        errors: {}
+    }, "Usage_head": {
+        request: undefined,
+        parameters: {
+            path: undefined,
+            query: usageHeadQueryParamsSchema,
+            header: undefined
+        },
+        responses: {
+            200: usageHeadQueryResponseSchema,
+            default: usageHeadQueryResponseSchema
         },
         errors: {}
     }, "Monitoring_health": {
@@ -277,6 +325,18 @@ export type UsageTransferQueryResponseSchema = z.infer<typeof usageTransferQuery
         responses: {
             200: monitoringHealthQueryResponseSchema,
             default: monitoringHealthQueryResponseSchema
+        },
+        errors: {}
+    }, "Usage_holders": {
+        request: undefined,
+        parameters: {
+            path: undefined,
+            query: usageHoldersQueryParamsSchema,
+            header: undefined
+        },
+        responses: {
+            200: usageHoldersQueryResponseSchema,
+            default: usageHoldersQueryResponseSchema
         },
         errors: {}
     }, "Monitoring_metrics": {
@@ -303,6 +363,66 @@ export type UsageTransferQueryResponseSchema = z.infer<typeof usageTransferQuery
             default: docsOpenapiQueryResponseSchema
         },
         errors: {}
+    }, "Usage_supply": {
+        request: undefined,
+        parameters: {
+            path: undefined,
+            query: usageSupplyQueryParamsSchema,
+            header: undefined
+        },
+        responses: {
+            200: usageSupplyQueryResponseSchema,
+            default: usageSupplyQueryResponseSchema
+        },
+        errors: {}
+    }, "Usage_tokens": {
+        request: undefined,
+        parameters: {
+            path: undefined,
+            query: usageTokensQueryParamsSchema,
+            header: undefined
+        },
+        responses: {
+            200: usageTokensQueryResponseSchema,
+            default: usageTokensQueryResponseSchema
+        },
+        errors: {}
+    }, "Usage_transfers": {
+        request: undefined,
+        parameters: {
+            path: undefined,
+            query: usageTransfersQueryParamsSchema,
+            header: undefined
+        },
+        responses: {
+            200: usageTransfersQueryResponseSchema,
+            default: usageTransfersQueryResponseSchema
+        },
+        errors: {}
+    }, "Usage_transfersAccount": {
+        request: undefined,
+        parameters: {
+            path: undefined,
+            query: usageTransfersAccountQueryParamsSchema,
+            header: undefined
+        },
+        responses: {
+            200: usageTransfersAccountQueryResponseSchema,
+            default: usageTransfersAccountQueryResponseSchema
+        },
+        errors: {}
+    }, "Usage_transferId": {
+        request: undefined,
+        parameters: {
+            path: undefined,
+            query: usageTransferIdQueryParamsSchema,
+            header: undefined
+        },
+        responses: {
+            200: usageTransferIdQueryResponseSchema,
+            default: usageTransferIdQueryResponseSchema
+        },
+        errors: {}
     }, "Docs_version": {
         request: undefined,
         parameters: {
@@ -315,99 +435,31 @@ export type UsageTransferQueryResponseSchema = z.infer<typeof usageTransferQuery
             default: docsVersionQueryResponseSchema
         },
         errors: {}
-    }, "Usage_balance": {
-        request: undefined,
-        parameters: {
-            path: usageBalancePathParamsSchema,
-            query: usageBalanceQueryParamsSchema,
-            header: undefined
-        },
-        responses: {
-            200: usageBalanceQueryResponseSchema,
-            default: usageBalanceQueryResponseSchema
-        },
-        errors: {}
-    }, "Usage_holders": {
-        request: undefined,
-        parameters: {
-            path: usageHoldersPathParamsSchema,
-            query: usageHoldersQueryParamsSchema,
-            header: undefined
-        },
-        responses: {
-            200: usageHoldersQueryResponseSchema,
-            default: usageHoldersQueryResponseSchema
-        },
-        errors: {}
-    }, "Usage_supply": {
-        request: undefined,
-        parameters: {
-            path: usageSupplyPathParamsSchema,
-            query: usageSupplyQueryParamsSchema,
-            header: undefined
-        },
-        responses: {
-            200: usageSupplyQueryResponseSchema,
-            default: usageSupplyQueryResponseSchema
-        },
-        errors: {}
-    }, "Usage_tokens": {
-        request: undefined,
-        parameters: {
-            path: usageTokensPathParamsSchema,
-            query: usageTokensQueryParamsSchema,
-            header: undefined
-        },
-        responses: {
-            200: usageTokensQueryResponseSchema,
-            default: usageTokensQueryResponseSchema
-        },
-        errors: {}
-    }, "Usage_transfers": {
-        request: undefined,
-        parameters: {
-            path: usageTransfersPathParamsSchema,
-            query: usageTransfersQueryParamsSchema,
-            header: undefined
-        },
-        responses: {
-            200: usageTransfersQueryResponseSchema,
-            default: usageTransfersQueryResponseSchema
-        },
-        errors: {}
-    }, "Usage_transfer": {
-        request: undefined,
-        parameters: {
-            path: usageTransferPathParamsSchema,
-            query: usageTransferQueryParamsSchema,
-            header: undefined
-        },
-        responses: {
-            200: usageTransferQueryResponseSchema,
-            default: usageTransferQueryResponseSchema
-        },
-        errors: {}
     } } as const;
-export const paths = { "/chains": {
-        get: operations["Usage_chains"]
+export const paths = { "/balance": {
+        get: operations["Usage_balance"]
+    }, "/balance/historical": {
+        get: operations["Usage_balanceHistorical"]
+    }, "/head": {
+        get: operations["Usage_head"]
     }, "/health": {
         get: operations["Monitoring_health"]
+    }, "/holders": {
+        get: operations["Usage_holders"]
     }, "/metrics": {
         get: operations["Monitoring_metrics"]
     }, "/openapi": {
         get: operations["Docs_openapi"]
+    }, "/supply": {
+        get: operations["Usage_supply"]
+    }, "/tokens": {
+        get: operations["Usage_tokens"]
+    }, "/transfers": {
+        get: operations["Usage_transfers"]
+    }, "/transfers/account": {
+        get: operations["Usage_transfersAccount"]
+    }, "/transfers/id": {
+        get: operations["Usage_transferId"]
     }, "/version": {
         get: operations["Docs_version"]
-    }, "/{chain}/balance": {
-        get: operations["Usage_balance"]
-    }, "/{chain}/holders": {
-        get: operations["Usage_holders"]
-    }, "/{chain}/supply": {
-        get: operations["Usage_supply"]
-    }, "/{chain}/tokens": {
-        get: operations["Usage_tokens"]
-    }, "/{chain}/transfers": {
-        get: operations["Usage_transfers"]
-    }, "/{chain}/transfers/{trx_id}": {
-        get: operations["Usage_transfer"]
     } } as const;

--- a/src/typespec/config.js
+++ b/src/typespec/config.js
@@ -1,0 +1,1 @@
+const TEST = "ABC";

--- a/src/typespec/openapi3.tsp
+++ b/src/typespec/openapi3.tsp
@@ -1,23 +1,26 @@
 import "@typespec/http";
 import "@typespec/openapi";
 import "./models.tsp";
+import "./config.js";
 
 using TypeSpec.Http;
 using TypeSpec.OpenAPI;
 
-@service({ title: "Antelope Token API" })
+@service({ title: "Antelope Token Api" })
 @info({
     summary: "Tokens information from the Antelope blockchains, powered by Substreams",
     license: {
         name: "MIT",
         url: "https://github.com/pinax-network/antelope-token-api/blob/4f4bf36341b794c0ccf5b7a14fdf810be06462d2/LICENSE"
     },
-    version: "5.0.0"
+    version: "6.0.0"
 }) // From @typespec/openapi
-namespace AntelopeTokenAPI;
+//@server("https://eos.api.pinax.network/v1", "EOS V1 Api Endpoint")
+namespace AntelopeTokenApi;
 
+alias ApiKeyHeader = "X-Api-Key";
 // Error codes adapted from https://github.com/pinax-network/golang-base/blob/develop/response/errors.go
-alias APIErrorCode =
+alias ApiErrorCode =
     | "bad_database_response" // invalid response from the database
     | "bad_header" // invalid or malformed header given
     | "missing_required_header" // request is missing a header
@@ -32,13 +35,16 @@ alias APIErrorCode =
 alias ErrorStatusCode = 500 | 504 | 400 | 401 | 403 | 404 | 405;
 
 @error
-model APIError {
+model ApiError {
     status: ErrorStatusCode;
-    code: APIErrorCode;
+    code: ApiErrorCode;
     message: string;
 }
 
 alias TimestampType = string;
+// Helper aliases for accessing underlying properties
+alias BlockInfo = Models.BlockInfo<TimestampType>;
+alias TokenIdentifier = Models.Scope;
 
 // Models will be present in the OpenAPI components
 model Transfer is Models.Transfer<TimestampType>;
@@ -47,6 +53,11 @@ model Supply is Models.Supply<TimestampType>;
 model Holder {
     account: BalanceChange.account;
     balance: BalanceChange.value;
+}
+model Balance {
+    last_updated_block: BalanceChange.block_num,
+    ...TokenIdentifier,
+    balance: BalanceChange.value
 }
 
 model QueryStatistics {
@@ -72,51 +83,59 @@ model UsageResponse<T> {
     meta: ResponseMetadata;
 }
 
-enum SupportedChains {
-    EOS,
-    WAX
-}
-
 // Alias will *not* be present in the OpenAPI components.
 // This also helps preventing self-references in generated `components` for codegen to work properly.
-alias APIResponse<T> = T | APIError;
+alias ApiResponse<T> = T | ApiError;
 alias PaginationQueryParams = {
     @query limit?: uint64 = 10;
     @query page?: uint64 = 1;
 };
 
-// Helper aliases for accessing underlying properties
-alias BlockInfo = Models.BlockInfo<TimestampType>;
-alias TokenIdentifier = Models.Scope;
-
 @tag("Usage")
 interface Usage {
     /**
-        Balances of an account.
+        Token balances of an account.
         @returns Array of balances.
     */
-    @summary("Token balance")
-    @route("/{chain}/balance")
+    @summary("Token balances")
+    @route("/balance")
     @get
+    @useAuth(ApiKeyAuth<ApiKeyLocation.header, ApiKeyHeader>)
     balance(
-        @path chain: SupportedChains,
-        @query block_num?: BlockInfo.block_num,
+        @query account: BalanceChange.account,
         @query contract?: TokenIdentifier.contract,
         @query symcode?: TokenIdentifier.symcode,
-        @query account: BalanceChange.account,
         ...PaginationQueryParams,
-    ): APIResponse<UsageResponse<BalanceChange[]>>;
+    ): ApiResponse<UsageResponse<Balance[]>>;
 
     /**
-        List of available Antelope chains and corresponding latest block for which data is available.
-        @returns Array of block information.
+        Historical token balances of an account.
+        @returns Array of balances.
     */
-    @summary("Chains and latest block available")
-    @route("/chains")
+    @summary("Historical token balances")
+    @route("/balance/historical")
     @get
-    chains(...PaginationQueryParams): APIResponse<UsageResponse<{
-        chain: SupportedChains,
-        block_num: BlockInfo.block_num;
+    @useAuth(ApiKeyAuth<ApiKeyLocation.header, ApiKeyHeader>)
+    balanceHistorical(
+        @query account: BalanceChange.account,
+        @query block_num: BlockInfo.block_num,
+        @query contract?: TokenIdentifier.contract,
+        @query symcode?: TokenIdentifier.symcode,
+        ...PaginationQueryParams,
+    ): ApiResponse<UsageResponse<BalanceChange[]>>;
+
+    /**
+        Current head block for which data is available (can be lower than head block of the chain).
+        @returns Head block information.
+    */
+    @summary("Head block information")
+    @route("/head")
+    @get
+    head(
+        ...PaginationQueryParams
+    ): ApiResponse<UsageResponse<{
+        block_num: BlockInfo.block_num,
+        block_id: string
     }[]>>;
 
     /**
@@ -124,75 +143,88 @@ interface Usage {
         @returns Array of accounts.
     */
     @summary("Token holders")
-    @route("/{chain}/holders")
+    @route("/holders")
     @get
+    @useAuth(ApiKeyAuth<ApiKeyLocation.header, ApiKeyHeader>)
     holders(
-        @path chain: SupportedChains,
         @query contract: TokenIdentifier.contract,
         @query symcode: TokenIdentifier.symcode,
         ...PaginationQueryParams,
-    ): APIResponse<UsageResponse<Holder[]>>;
+    ): ApiResponse<UsageResponse<Holder[]>>;
 
     /**
         Total supply for a token.
         @returns Array of supplies.
     */
     @summary("Token supply")
-    @route("/{chain}/supply")
+    @route("/supply")
     @get
+    @useAuth(ApiKeyAuth<ApiKeyLocation.header, ApiKeyHeader>)
     supply(
-        @path chain: SupportedChains,
         @query block_num?: BlockInfo.block_num,
         @query issuer?: Supply.issuer,
         @query contract: TokenIdentifier.contract,
         @query symcode: TokenIdentifier.symcode,
         ...PaginationQueryParams,
-    ): APIResponse<UsageResponse<Supply[]>>;
+    ): ApiResponse<UsageResponse<Supply[]>>;
 
     /**
         List of available tokens.
-        @returns Array of supplies.
+        @returns Array of token identifier.
     */
     @summary("Tokens")
-    @route("/{chain}/tokens")
+    @route("/tokens")
     @get
+    @useAuth(ApiKeyAuth<ApiKeyLocation.header, ApiKeyHeader>)
     tokens(
-        @path chain: SupportedChains,
         ...PaginationQueryParams
-    ): APIResponse<UsageResponse<Supply[]>>;
+    ): ApiResponse<UsageResponse<TokenIdentifier[]>>;
 
     /**
         All transfers related to a token.
         @returns Array of transfers.
     */
     @summary("Token transfers")
-    @route("/{chain}/transfers")
+    @route("/transfers")
     @get
+    @useAuth(ApiKeyAuth<ApiKeyLocation.header, ApiKeyHeader>)
     transfers(
-        @path chain: SupportedChains,
-        @query({
-            format: "csv",
-        })
-        block_range?: BlockInfo.block_num[],
+        @query({ format: "csv"}) block_range?: BlockInfo.block_num[],
+        @query contract: TokenIdentifier.contract,
+        @query symcode: TokenIdentifier.symcode,
+        ...PaginationQueryParams,
+    ): ApiResponse<UsageResponse<Transfer[]>>;
+
+    /**
+        All transfers related to an account.
+        @returns Array of transfers.
+    */
+    @summary("Token transfers from and to an account")
+    @route("/transfers/account")
+    @get
+    @useAuth(ApiKeyAuth<ApiKeyLocation.header, ApiKeyHeader>)
+    transfersAccount(
+        @query account: BalanceChange.account,
+        @query({ format: "csv"}) block_range?: BlockInfo.block_num[],
         @query from?: Transfer.from,
         @query to?: Transfer.to,
         @query contract?: TokenIdentifier.contract,
         @query symcode?: TokenIdentifier.symcode,
         ...PaginationQueryParams,
-    ): APIResponse<UsageResponse<Transfer[]>>;
+    ): ApiResponse<UsageResponse<Transfer[]>>;
 
     /**
         Specific transfer related to a token.
         @returns Array of transfers.
     */
     @summary("Token transfer")
-    @route("/{chain}/transfers/{trx_id}")
+    @route("/transfers/id")
     @get
-    transfer(
-        @path chain: SupportedChains,
-        @path trx_id: Models.TraceInformation.trx_id,
+    @useAuth(ApiKeyAuth<ApiKeyLocation.header, ApiKeyHeader>)
+    transferId(
+        @query trx_id: Models.TraceInformation.trx_id,
         ...PaginationQueryParams,
-    ): APIResponse<UsageResponse<Transfer[]>>;
+    ): ApiResponse<UsageResponse<Transfer[]>>;
 }
 
 model Version {
@@ -212,28 +244,28 @@ interface Docs {
     @summary("OpenAPI JSON spec")
     @route("/openapi")
     @get
-    openapi(): APIResponse<Record<unknown>>;
+    openapi(): ApiResponse<Record<unknown>>;
 
     /**
-        API version and Git short commit hash.
-        @returns The API version and commit hash.
+        Api version and Git short commit hash.
+        @returns The Api version and commit hash.
     */
-    @summary("API version")
+    @summary("Api version")
     @route("/version")
     @get
-    version(): APIResponse<Version>;
+    version(): ApiResponse<Version>;
 }
 
 @tag("Monitoring")
 interface Monitoring {
     /**
         Checks database connection.
-        @returns OK or APIError.
+        @returns OK or ApiError.
     */
     @summary("Health check")
     @route("/health")
     @get
-    health(): APIResponse<string>;
+    health(): ApiResponse<string>;
 
     /**
         Prometheus metrics.
@@ -242,5 +274,5 @@ interface Monitoring {
     @summary("Prometheus metrics")
     @route("/metrics")
     @get
-    metrics(): APIResponse<string>;
+    metrics(): ApiResponse<string>;
 }

--- a/static/@openapi-to-graphql/graphql/schema.graphql
+++ b/static/@openapi-to-graphql/graphql/schema.graphql
@@ -1,17 +1,24 @@
 type Query {
   """
-  Balances of an account.
+  Token balances of an account.
   
-  Equivalent to GET /{chain}/balance
+  Equivalent to GET /balance
   """
-  balance(account: String!, block_num: Int, chain: Chain!, contract: String, limit: Int, page: Int, symcode: String): Balance
+  balance(account: String!, contract: String, limit: Int, page: Int, symcode: String): Balance
 
   """
-  List of available Antelope chains and corresponding latest block for which data is available.
+  Historical token balances of an account.
   
-  Equivalent to GET /chains
+  Equivalent to GET /balance/historical
   """
-  chains(limit: Int, page: Int): Chains
+  balanceHistorical(account: String!, block_num: Int!, contract: String, limit: Int, page: Int, symcode: String): BalanceHistorical
+
+  """
+  Current head block for which data is available (can be lower than head block of the chain).
+  
+  Equivalent to GET /head
+  """
+  head(limit: Int, page: Int): Head
 
   """
   Checks database connection.
@@ -23,9 +30,9 @@ type Query {
   """
   List of holders of a token.
   
-  Equivalent to GET /{chain}/holders
+  Equivalent to GET /holders
   """
-  holders(chain: Chain!, contract: String!, limit: Int, page: Int, symcode: String!): Holders
+  holders(contract: String!, limit: Int, page: Int, symcode: String!): Holders
 
   """
   Prometheus metrics.
@@ -44,33 +51,40 @@ type Query {
   """
   Total supply for a token.
   
-  Equivalent to GET /{chain}/supply
+  Equivalent to GET /supply
   """
-  supply(block_num: Int, chain: Chain!, contract: String!, issuer: String, limit: Int, page: Int, symcode: String!): Supply
+  supply(block_num: Int, contract: String!, issuer: String, limit: Int, page: Int, symcode: String!): Supply
 
   """
   List of available tokens.
   
-  Equivalent to GET /{chain}/tokens
+  Equivalent to GET /tokens
   """
-  tokens(chain: Chain!, limit: Int, page: Int): Tokens
-
-  """
-  Specific transfer related to a token.
-  
-  Equivalent to GET /{chain}/transfers/{trx_id}
-  """
-  transfer(chain: Chain!, limit: Int, page: Int, trx_id: String!): Transfer2
+  tokens(limit: Int, page: Int): Tokens
 
   """
   All transfers related to a token.
   
-  Equivalent to GET /{chain}/transfers
+  Equivalent to GET /transfers
   """
-  transfers(block_range: [Int], chain: Chain!, contract: String, from: String, limit: Int, page: Int, symcode: String, to: String): Transfers
+  transfers(block_range: [Int], contract: String!, limit: Int, page: Int, symcode: String!): Transfers
 
   """
-  API version and Git short commit hash.
+  All transfers related to an account.
+  
+  Equivalent to GET /transfers/account
+  """
+  transfersAccount(account: String!, block_range: [Int], contract: String, from: String, limit: Int, page: Int, symcode: String, to: String): TransfersAccount
+
+  """
+  Specific transfer related to a token.
+  
+  Equivalent to GET /transfers/id
+  """
+  transfersId(limit: Int, page: Int, trx_id: String!): TransfersId
+
+  """
+  Api version and Git short commit hash.
   
   Equivalent to GET /version
   """
@@ -78,6 +92,37 @@ type Query {
 }
 
 type Balance {
+  data: [Balance2]!
+  meta: ResponseMetadata!
+}
+
+type Balance2 {
+  balance: Float!
+  contract: String!
+  last_updated_block: Int!
+  symcode: String!
+}
+
+type ResponseMetadata {
+  next_page: BigInt!
+  previous_page: BigInt!
+  statistics: Statistics!
+  total_pages: BigInt!
+  total_results: BigInt!
+}
+
+"""
+The `BigInt` scalar type represents non-fractional signed whole numeric values.
+"""
+scalar BigInt
+
+type Statistics {
+  bytes_read: BigInt!
+  elapsed: Float!
+  rows_read: BigInt!
+}
+
+type BalanceHistorical {
   data: [BalanceChange]!
   meta: ResponseMetadata!
 }
@@ -97,43 +142,14 @@ type BalanceChange {
   value: Float!
 }
 
-"""
-The `BigInt` scalar type represents non-fractional signed whole numeric values.
-"""
-scalar BigInt
-
-type ResponseMetadata {
-  next_page: BigInt!
-  previous_page: BigInt!
-  statistics: Statistics!
-  total_pages: BigInt!
-  total_results: BigInt!
-}
-
-type Statistics {
-  bytes_read: BigInt!
-  elapsed: Float!
-  rows_read: BigInt!
-}
-
-enum Chain {
-  EOS
-  WAX
-}
-
-type Chains {
-  data: [DataListItem]!
+type Head {
+  data: [Data3ListItem]!
   meta: ResponseMetadata!
 }
 
-type DataListItem {
+type Data3ListItem {
+  block_id: String!
   block_num: Int!
-  chain: SupportedChains!
-}
-
-enum SupportedChains {
-  EOS
-  WAX
 }
 
 type Holders {
@@ -173,11 +189,16 @@ type Supply2 {
 }
 
 type Tokens {
-  data: [Supply2]!
+  data: [ModelsScope]!
   meta: ResponseMetadata!
 }
 
-type Transfer2 {
+type ModelsScope {
+  contract: String!
+  symcode: String!
+}
+
+type Transfers {
   data: [Transfer]!
   meta: ResponseMetadata!
 }
@@ -198,7 +219,12 @@ type Transfer {
   value: Float!
 }
 
-type Transfers {
+type TransfersAccount {
+  data: [Transfer]!
+  meta: ResponseMetadata!
+}
+
+type TransfersId {
   data: [Transfer]!
   meta: ResponseMetadata!
 }

--- a/static/@typespec/openapi3/openapi.json
+++ b/static/@typespec/openapi3/openapi.json
@@ -1,13 +1,13 @@
 {
   "openapi": "3.0.0",
   "info": {
-    "title": "Antelope Token API",
+    "title": "Antelope Token Api",
     "summary": "Tokens information from the Antelope blockchains, powered by Substreams",
     "license": {
       "name": "MIT",
       "url": "https://github.com/pinax-network/antelope-token-api/blob/4f4bf36341b794c0ccf5b7a14fdf810be06462d2/LICENSE"
     },
-    "version": "5.0.0"
+    "version": "6.0.0"
   },
   "tags": [
     {
@@ -21,15 +21,39 @@
     }
   ],
   "paths": {
-    "/chains": {
+    "/balance": {
       "get": {
         "tags": [
           "Usage"
         ],
-        "operationId": "Usage_chains",
-        "summary": "Chains and latest block available",
-        "description": "List of available Antelope chains and corresponding latest block for which data is available.",
+        "operationId": "Usage_balance",
+        "summary": "Token balances",
+        "description": "Token balances of an account.",
         "parameters": [
+          {
+            "name": "account",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "contract",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "symcode",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
           {
             "name": "limit",
             "in": "query",
@@ -53,7 +77,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Array of block information.",
+            "description": "Array of balances.",
             "content": {
               "application/json": {
                 "schema": {
@@ -66,20 +90,7 @@
                     "data": {
                       "type": "array",
                       "items": {
-                        "type": "object",
-                        "properties": {
-                          "chain": {
-                            "$ref": "#/components/schemas/SupportedChains"
-                          },
-                          "block_num": {
-                            "type": "integer",
-                            "format": "uint64"
-                          }
-                        },
-                        "required": [
-                          "chain",
-                          "block_num"
-                        ]
+                        "$ref": "#/components/schemas/Balance"
                       }
                     },
                     "meta": {
@@ -95,168 +106,40 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIError"
+                  "$ref": "#/components/schemas/ApiError"
                 }
               }
             }
           }
-        }
-      }
-    },
-    "/health": {
-      "get": {
-        "tags": [
-          "Monitoring"
-        ],
-        "operationId": "Monitoring_health",
-        "summary": "Health check",
-        "description": "Checks database connection.",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "OK or APIError.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/APIError"
-                }
-              }
-            }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
           }
-        }
+        ]
       }
     },
-    "/metrics": {
-      "get": {
-        "tags": [
-          "Monitoring"
-        ],
-        "operationId": "Monitoring_metrics",
-        "summary": "Prometheus metrics",
-        "description": "Prometheus metrics.",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "Metrics as text.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/APIError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/openapi": {
-      "get": {
-        "tags": [
-          "Docs"
-        ],
-        "operationId": "Docs_openapi",
-        "summary": "OpenAPI JSON spec",
-        "description": "Reflection endpoint to return OpenAPI JSON spec. Also used by Swagger to generate the frontpage.",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "The OpenAPI JSON spec",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": {}
-                }
-              }
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/APIError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/version": {
-      "get": {
-        "tags": [
-          "Docs"
-        ],
-        "operationId": "Docs_version",
-        "summary": "API version",
-        "description": "API version and Git short commit hash.",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "The API version and commit hash.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Version"
-                }
-              }
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/APIError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/{chain}/balance": {
+    "/balance/historical": {
       "get": {
         "tags": [
           "Usage"
         ],
-        "operationId": "Usage_balance",
-        "summary": "Token balance",
-        "description": "Balances of an account.",
+        "operationId": "Usage_balanceHistorical",
+        "summary": "Historical token balances",
+        "description": "Historical token balances of an account.",
         "parameters": [
           {
-            "name": "chain",
-            "in": "path",
+            "name": "account",
+            "in": "query",
             "required": true,
             "schema": {
-              "$ref": "#/components/schemas/SupportedChains"
+              "type": "string"
             }
           },
           {
             "name": "block_num",
             "in": "query",
-            "required": false,
+            "required": true,
             "schema": {
               "type": "integer",
               "format": "uint64"
@@ -274,14 +157,6 @@
             "name": "symcode",
             "in": "query",
             "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "account",
-            "in": "query",
-            "required": true,
             "schema": {
               "type": "string"
             }
@@ -338,7 +213,94 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIError"
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ]
+      }
+    },
+    "/head": {
+      "get": {
+        "tags": [
+          "Usage"
+        ],
+        "operationId": "Usage_head",
+        "summary": "Head block information",
+        "description": "Current head block for which data is available (can be lower than head block of the chain).",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "uint64",
+              "default": 10
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "uint64",
+              "default": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Head block information.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "block_num": {
+                            "type": "integer",
+                            "format": "uint64"
+                          },
+                          "block_id": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "block_num",
+                          "block_id"
+                        ]
+                      }
+                    },
+                    "meta": {
+                      "$ref": "#/components/schemas/ResponseMetadata"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
                 }
               }
             }
@@ -346,7 +308,40 @@
         }
       }
     },
-    "/{chain}/holders": {
+    "/health": {
+      "get": {
+        "tags": [
+          "Monitoring"
+        ],
+        "operationId": "Monitoring_health",
+        "summary": "Health check",
+        "description": "Checks database connection.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "OK or ApiError.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/holders": {
       "get": {
         "tags": [
           "Usage"
@@ -355,14 +350,6 @@
         "summary": "Token holders",
         "description": "List of holders of a token.",
         "parameters": [
-          {
-            "name": "chain",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "$ref": "#/components/schemas/SupportedChains"
-            }
-          },
           {
             "name": "contract",
             "in": "query",
@@ -431,7 +418,45 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIError"
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ]
+      }
+    },
+    "/metrics": {
+      "get": {
+        "tags": [
+          "Monitoring"
+        ],
+        "operationId": "Monitoring_metrics",
+        "summary": "Prometheus metrics",
+        "description": "Prometheus metrics.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Metrics as text.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
                 }
               }
             }
@@ -439,7 +464,41 @@
         }
       }
     },
-    "/{chain}/supply": {
+    "/openapi": {
+      "get": {
+        "tags": [
+          "Docs"
+        ],
+        "operationId": "Docs_openapi",
+        "summary": "OpenAPI JSON spec",
+        "description": "Reflection endpoint to return OpenAPI JSON spec. Also used by Swagger to generate the frontpage.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "The OpenAPI JSON spec",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/supply": {
       "get": {
         "tags": [
           "Usage"
@@ -448,14 +507,6 @@
         "summary": "Token supply",
         "description": "Total supply for a token.",
         "parameters": [
-          {
-            "name": "chain",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "$ref": "#/components/schemas/SupportedChains"
-            }
-          },
           {
             "name": "block_num",
             "in": "query",
@@ -541,15 +592,20 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIError"
+                  "$ref": "#/components/schemas/ApiError"
                 }
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ]
       }
     },
-    "/{chain}/tokens": {
+    "/tokens": {
       "get": {
         "tags": [
           "Usage"
@@ -559,11 +615,107 @@
         "description": "List of available tokens.",
         "parameters": [
           {
-            "name": "chain",
-            "in": "path",
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "uint64",
+              "default": 10
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "uint64",
+              "default": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Array of token identifier.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Models.Scope"
+                      }
+                    },
+                    "meta": {
+                      "$ref": "#/components/schemas/ResponseMetadata"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ]
+      }
+    },
+    "/transfers": {
+      "get": {
+        "tags": [
+          "Usage"
+        ],
+        "operationId": "Usage_transfers",
+        "summary": "Token transfers",
+        "description": "All transfers related to a token.",
+        "parameters": [
+          {
+            "name": "block_range",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "format": "uint64"
+              }
+            },
+            "style": "form",
+            "explode": false
+          },
+          {
+            "name": "contract",
+            "in": "query",
             "required": true,
             "schema": {
-              "$ref": "#/components/schemas/SupportedChains"
+              "type": "string"
+            }
+          },
+          {
+            "name": "symcode",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
             }
           },
           {
@@ -589,7 +741,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Array of supplies.",
+            "description": "Array of transfers.",
             "content": {
               "application/json": {
                 "schema": {
@@ -602,7 +754,7 @@
                     "data": {
                       "type": "array",
                       "items": {
-                        "$ref": "#/components/schemas/Supply"
+                        "$ref": "#/components/schemas/Transfer"
                       }
                     },
                     "meta": {
@@ -618,29 +770,34 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIError"
+                  "$ref": "#/components/schemas/ApiError"
                 }
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ]
       }
     },
-    "/{chain}/transfers": {
+    "/transfers/account": {
       "get": {
         "tags": [
           "Usage"
         ],
-        "operationId": "Usage_transfers",
-        "summary": "Token transfers",
-        "description": "All transfers related to a token.",
+        "operationId": "Usage_transfersAccount",
+        "summary": "Token transfers from and to an account",
+        "description": "All transfers related to an account.",
         "parameters": [
           {
-            "name": "chain",
-            "in": "path",
+            "name": "account",
+            "in": "query",
             "required": true,
             "schema": {
-              "$ref": "#/components/schemas/SupportedChains"
+              "type": "string"
             }
           },
           {
@@ -741,34 +898,31 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIError"
+                  "$ref": "#/components/schemas/ApiError"
                 }
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ]
       }
     },
-    "/{chain}/transfers/{trx_id}": {
+    "/transfers/id": {
       "get": {
         "tags": [
           "Usage"
         ],
-        "operationId": "Usage_transfer",
+        "operationId": "Usage_transferId",
         "summary": "Token transfer",
         "description": "Specific transfer related to a token.",
         "parameters": [
           {
-            "name": "chain",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "$ref": "#/components/schemas/SupportedChains"
-            }
-          },
-          {
             "name": "trx_id",
-            "in": "path",
+            "in": "query",
             "required": true,
             "schema": {
               "type": "string"
@@ -826,7 +980,45 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIError"
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ]
+      }
+    },
+    "/version": {
+      "get": {
+        "tags": [
+          "Docs"
+        ],
+        "operationId": "Docs_version",
+        "summary": "Api version",
+        "description": "Api version and Git short commit hash.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "The Api version and commit hash.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Version"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
                 }
               }
             }
@@ -837,7 +1029,7 @@
   },
   "components": {
     "schemas": {
-      "APIError": {
+      "ApiError": {
         "type": "object",
         "required": [
           "status",
@@ -874,6 +1066,31 @@
           },
           "message": {
             "type": "string"
+          }
+        }
+      },
+      "Balance": {
+        "type": "object",
+        "required": [
+          "last_updated_block",
+          "contract",
+          "symcode",
+          "balance"
+        ],
+        "properties": {
+          "last_updated_block": {
+            "type": "integer",
+            "format": "uint64"
+          },
+          "contract": {
+            "type": "string"
+          },
+          "symcode": {
+            "type": "string"
+          },
+          "balance": {
+            "type": "number",
+            "format": "double"
           }
         }
       },
@@ -951,6 +1168,21 @@
           "balance": {
             "type": "number",
             "format": "double"
+          }
+        }
+      },
+      "Models.Scope": {
+        "type": "object",
+        "required": [
+          "contract",
+          "symcode"
+        ],
+        "properties": {
+          "contract": {
+            "type": "string"
+          },
+          "symcode": {
+            "type": "string"
           }
         }
       },
@@ -1104,13 +1336,6 @@
           }
         }
       },
-      "SupportedChains": {
-        "type": "string",
-        "enum": [
-          "EOS",
-          "WAX"
-        ]
-      },
       "Transfer": {
         "type": "object",
         "required": [
@@ -1191,6 +1416,13 @@
             "pattern": "^[0-9a-f]{7}$"
           }
         }
+      }
+    },
+    "securitySchemes": {
+      "ApiKeyAuth": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-Api-Key"
       }
     }
   }

--- a/swagger/index.html
+++ b/swagger/index.html
@@ -16,10 +16,11 @@
   <script src="https://unpkg.com/swagger-ui-dist@latest/swagger-ui-bundle.js" crossorigin></script>
   <script src="https://unpkg.com/swagger-ui-dist@latest/swagger-ui-standalone-preset.js" crossorigin></script>
   <script>
+    // https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/
     window.onload = () => {
       window.ui = SwaggerUIBundle({
-        url: '/openapi',
         dom_id: '#swagger-ui',
+        url: '/openapi',
         presets: [
           SwaggerUIBundle.presets.apis,
           SwaggerUIStandalonePreset

--- a/tsp-output/@typespec/openapi3/openapi.json
+++ b/tsp-output/@typespec/openapi3/openapi.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.0.0",
   "info": {
-    "title": "Antelope Token API",
+    "title": "Antelope Token Api",
     "summary": "Tokens information from the Antelope blockchains, powered by Substreams",
     "license": {
       "name": "MIT",
@@ -21,15 +21,39 @@
     }
   ],
   "paths": {
-    "/chains": {
+    "/balance": {
       "get": {
         "tags": [
           "Usage"
         ],
-        "operationId": "Usage_chains",
-        "summary": "Chains and latest block available",
-        "description": "List of available Antelope chains and corresponding latest block for which data is available.",
+        "operationId": "Usage_balance",
+        "summary": "Token balance",
+        "description": "Token balances of an account.",
         "parameters": [
+          {
+            "name": "account",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "contract",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "symcode",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
           {
             "name": "limit",
             "in": "query",
@@ -53,7 +77,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Array of block information.",
+            "description": "Array of balances.",
             "content": {
               "application/json": {
                 "schema": {
@@ -66,20 +90,7 @@
                     "data": {
                       "type": "array",
                       "items": {
-                        "type": "object",
-                        "properties": {
-                          "chain": {
-                            "$ref": "#/components/schemas/SupportedChains"
-                          },
-                          "block_num": {
-                            "type": "integer",
-                            "format": "uint64"
-                          }
-                        },
-                        "required": [
-                          "chain",
-                          "block_num"
-                        ]
+                        "$ref": "#/components/schemas/Balance"
                       }
                     },
                     "meta": {
@@ -95,159 +106,40 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIError"
+                  "$ref": "#/components/schemas/ApiError"
                 }
               }
             }
           }
-        }
-      }
-    },
-    "/health": {
-      "get": {
-        "tags": [
-          "Monitoring"
-        ],
-        "operationId": "Monitoring_health",
-        "summary": "Health check",
-        "description": "Checks database connection.",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "OK or APIError.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/APIError"
-                }
-              }
-            }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
           }
-        }
+        ]
       }
     },
-    "/metrics": {
-      "get": {
-        "tags": [
-          "Monitoring"
-        ],
-        "operationId": "Monitoring_metrics",
-        "summary": "Prometheus metrics",
-        "description": "Prometheus metrics.",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "Metrics as text.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": {}
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/openapi": {
-      "get": {
-        "tags": [
-          "Docs"
-        ],
-        "operationId": "Docs_openapi",
-        "summary": "OpenAPI JSON spec",
-        "description": "Reflection endpoint to return OpenAPI JSON spec. Also used by Swagger to generate the frontpage.",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "The OpenAPI JSON spec",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": {}
-                }
-              }
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/APIError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/version": {
-      "get": {
-        "tags": [
-          "Docs"
-        ],
-        "operationId": "Docs_version",
-        "summary": "API version",
-        "description": "API version and Git short commit hash.",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "The API version and commit hash.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Version"
-                }
-              }
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/APIError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/{chain}/balance": {
+    "/balance/historical": {
       "get": {
         "tags": [
           "Usage"
         ],
-        "operationId": "Usage_balance",
+        "operationId": "Usage_balance_historical",
         "summary": "Token balance",
-        "description": "Balances of an account.",
+        "description": "Historical token balances of an account.",
         "parameters": [
           {
-            "name": "chain",
-            "in": "path",
+            "name": "account",
+            "in": "query",
             "required": true,
             "schema": {
-              "$ref": "#/components/schemas/SupportedChains"
+              "type": "string"
             }
           },
           {
             "name": "block_num",
             "in": "query",
-            "required": false,
+            "required": true,
             "schema": {
               "type": "integer",
               "format": "uint64"
@@ -265,14 +157,6 @@
             "name": "symcode",
             "in": "query",
             "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "account",
-            "in": "query",
-            "required": true,
             "schema": {
               "type": "string"
             }
@@ -329,7 +213,94 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIError"
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ]
+      }
+    },
+    "/head": {
+      "get": {
+        "tags": [
+          "Usage"
+        ],
+        "operationId": "Usage_head",
+        "summary": "Head block information",
+        "description": "Current head block for which data is available (can be lower than head block of the chain).",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "uint64",
+              "default": 10
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "uint64",
+              "default": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Head block information.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "block_num": {
+                            "type": "integer",
+                            "format": "uint64"
+                          },
+                          "block_id": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "block_num",
+                          "block_id"
+                        ]
+                      }
+                    },
+                    "meta": {
+                      "$ref": "#/components/schemas/ResponseMetadata"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
                 }
               }
             }
@@ -337,7 +308,40 @@
         }
       }
     },
-    "/{chain}/holders": {
+    "/health": {
+      "get": {
+        "tags": [
+          "Monitoring"
+        ],
+        "operationId": "Monitoring_health",
+        "summary": "Health check",
+        "description": "Checks database connection.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "OK or ApiError.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/holders": {
       "get": {
         "tags": [
           "Usage"
@@ -346,14 +350,6 @@
         "summary": "Token holders",
         "description": "List of holders of a token.",
         "parameters": [
-          {
-            "name": "chain",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "$ref": "#/components/schemas/SupportedChains"
-            }
-          },
           {
             "name": "contract",
             "in": "query",
@@ -422,7 +418,45 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIError"
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ]
+      }
+    },
+    "/metrics": {
+      "get": {
+        "tags": [
+          "Monitoring"
+        ],
+        "operationId": "Monitoring_metrics",
+        "summary": "Prometheus metrics",
+        "description": "Prometheus metrics.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Metrics as text.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
                 }
               }
             }
@@ -430,7 +464,41 @@
         }
       }
     },
-    "/{chain}/supply": {
+    "/openapi": {
+      "get": {
+        "tags": [
+          "Docs"
+        ],
+        "operationId": "Docs_openapi",
+        "summary": "OpenAPI JSON spec",
+        "description": "Reflection endpoint to return OpenAPI JSON spec. Also used by Swagger to generate the frontpage.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "The OpenAPI JSON spec",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/supply": {
       "get": {
         "tags": [
           "Usage"
@@ -439,14 +507,6 @@
         "summary": "Token supply",
         "description": "Total supply for a token.",
         "parameters": [
-          {
-            "name": "chain",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "$ref": "#/components/schemas/SupportedChains"
-            }
-          },
           {
             "name": "block_num",
             "in": "query",
@@ -532,15 +592,20 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIError"
+                  "$ref": "#/components/schemas/ApiError"
                 }
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ]
       }
     },
-    "/{chain}/tokens": {
+    "/tokens": {
       "get": {
         "tags": [
           "Usage"
@@ -550,11 +615,107 @@
         "description": "List of available tokens.",
         "parameters": [
           {
-            "name": "chain",
-            "in": "path",
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "uint64",
+              "default": 10
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "uint64",
+              "default": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Array of token identifier.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Models.Scope"
+                      }
+                    },
+                    "meta": {
+                      "$ref": "#/components/schemas/ResponseMetadata"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ]
+      }
+    },
+    "/transfers": {
+      "get": {
+        "tags": [
+          "Usage"
+        ],
+        "operationId": "Usage_transfers",
+        "summary": "Token transfers",
+        "description": "All transfers related to a token.",
+        "parameters": [
+          {
+            "name": "block_range",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "format": "uint64"
+              }
+            },
+            "style": "form",
+            "explode": false
+          },
+          {
+            "name": "contract",
+            "in": "query",
             "required": true,
             "schema": {
-              "$ref": "#/components/schemas/SupportedChains"
+              "type": "string"
+            }
+          },
+          {
+            "name": "symcode",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
             }
           },
           {
@@ -580,7 +741,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Array of supplies.",
+            "description": "Array of transfers.",
             "content": {
               "application/json": {
                 "schema": {
@@ -593,7 +754,7 @@
                     "data": {
                       "type": "array",
                       "items": {
-                        "$ref": "#/components/schemas/Supply"
+                        "$ref": "#/components/schemas/Transfer"
                       }
                     },
                     "meta": {
@@ -609,29 +770,34 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIError"
+                  "$ref": "#/components/schemas/ApiError"
                 }
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ]
       }
     },
-    "/{chain}/transfers": {
+    "/transfers/account": {
       "get": {
         "tags": [
           "Usage"
         ],
-        "operationId": "Usage_transfers",
-        "summary": "Token transfers",
-        "description": "All transfers related to a token.",
+        "operationId": "Usage_transfers_account",
+        "summary": "Token transfers from and to an account",
+        "description": "All transfers related to an account.",
         "parameters": [
           {
-            "name": "chain",
-            "in": "path",
+            "name": "account",
+            "in": "query",
             "required": true,
             "schema": {
-              "$ref": "#/components/schemas/SupportedChains"
+              "type": "string"
             }
           },
           {
@@ -732,15 +898,20 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIError"
+                  "$ref": "#/components/schemas/ApiError"
                 }
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ]
       }
     },
-    "/{chain}/transfers/{trx_id}": {
+    "/transfers/id": {
       "get": {
         "tags": [
           "Usage"
@@ -750,16 +921,8 @@
         "description": "Specific transfer related to a token.",
         "parameters": [
           {
-            "name": "chain",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "$ref": "#/components/schemas/SupportedChains"
-            }
-          },
-          {
             "name": "trx_id",
-            "in": "path",
+            "in": "query",
             "required": true,
             "schema": {
               "type": "string"
@@ -817,7 +980,45 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIError"
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ]
+      }
+    },
+    "/version": {
+      "get": {
+        "tags": [
+          "Docs"
+        ],
+        "operationId": "Docs_version",
+        "summary": "Api version",
+        "description": "Api version and Git short commit hash.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "The Api version and commit hash.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Version"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
                 }
               }
             }
@@ -828,7 +1029,7 @@
   },
   "components": {
     "schemas": {
-      "APIError": {
+      "ApiError": {
         "type": "object",
         "required": [
           "status",
@@ -865,6 +1066,31 @@
           },
           "message": {
             "type": "string"
+          }
+        }
+      },
+      "Balance": {
+        "type": "object",
+        "required": [
+          "last_updated_block",
+          "contract",
+          "symcode",
+          "balance"
+        ],
+        "properties": {
+          "last_updated_block": {
+            "type": "integer",
+            "format": "uint64"
+          },
+          "contract": {
+            "type": "string"
+          },
+          "symcode": {
+            "type": "string"
+          },
+          "balance": {
+            "type": "number",
+            "format": "double"
           }
         }
       },
@@ -942,6 +1168,21 @@
           "balance": {
             "type": "number",
             "format": "double"
+          }
+        }
+      },
+      "Models.Scope": {
+        "type": "object",
+        "required": [
+          "contract",
+          "symcode"
+        ],
+        "properties": {
+          "contract": {
+            "type": "string"
+          },
+          "symcode": {
+            "type": "string"
           }
         }
       },
@@ -1095,13 +1336,6 @@
           }
         }
       },
-      "SupportedChains": {
-        "type": "string",
-        "enum": [
-          "EOS",
-          "WAX"
-        ]
-      },
       "Transfer": {
         "type": "object",
         "required": [
@@ -1183,6 +1417,20 @@
           }
         }
       }
+    },
+    "securitySchemes": {
+      "ApiKeyAuth": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-Api-Key"
+      }
     }
-  }
+  },
+  "servers": [
+    {
+      "url": "https://eos.api.pinax.network/v1",
+      "description": "EOS V1 Api Endpoint",
+      "variables": {}
+    }
+  ]
 }


### PR DESCRIPTION
- Added `/transfers/account` endpoint for transfers related to/from a given account.
- Removed path parameter from `/transfers/{trx_id}`, now uses query parameter. Path changed to `/transfers/id`.
- Removed `from/to` query parameters from `/transfers` and requires `contract/symcode` instead.
- Added `/balance/historical` for block ranges queries.
- Added `X-Api-Key` header authentication support for Swagger/GraphQL.
- Fixed some endpoint return format
- Only support a single chain, `/chains` changed to `/head`.
- Updated GraphQL resolvers to support authentication parameters. Can also filter out some operations from the schema.
- Removed unused `TABLE` env variable.